### PR TITLE
Clean up imwrite debug functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,20 +31,20 @@ WORKDIR "$OPENCV_BUILD_DIR"
 ENV COMMON_CMAKE_FLAGS="-S $OPENCV_SRC_DIR \
         -B $OPENCV_BUILD_DIR \
         -D CMAKE_BUILD_TYPE=RELEASE \
-        -D WITH_OPENEXR=OFF \
-        -D WITH_GTK=OFF \
-        -D WITH_V4L=OFF \
-        -D WITH_FFMPEG=OFF \
-        -D WITH_GSTREAMER=OFF \
-        -D WITH_GSTREAMER_0_10=OFF \
-        -D BUILD_LIST=core,imgproc,video \
-        -D BUILD_EXAMPLES=OFF \
-        -D BUILD_OPENCV_APPS=OFF \
         -D BUILD_DOCS=OFF \
+        -D BUILD_EXAMPLES=OFF \
         -D BUILD_JPEG=ON \
+        -D BUILD_LIST=core,imgproc,video,imgcodecs \
+        -D BUILD_OPENCV_APPS=OFF \
         -D BUILD_PNG=OFF \
-        -D WITH_JASPER=OFF \
         -D BUILD_PROTOBUF=OFF \
+        -D WITH_FFMPEG=OFF \
+        -D WITH_GSTREAMER_0_10=OFF \
+        -D WITH_GSTREAMER=OFF \
+        -D WITH_GTK=OFF \
+        -D WITH_JASPER=OFF \
+        -D WITH_OPENEXR=OFF \
+        -D WITH_V4L=OFF \
         -D OPENCV_GENERATE_PKGCONFIG=ON "
 
 # hadolint ignore=SC2086

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
 
 CXXFLAGS += -I$(SDKTARGETSYSROOT)/usr/include/opencv4
 LDFLAGS = -L./lib -Wl,--no-as-needed,-rpath,'$$ORIGIN/lib'
-LDLIBS += -lm -lopencv_video -lopencv_imgproc -lopencv_core -lpthread
+LDLIBS += -lm -lopencv_core -lopencv_imgproc -lopencv_video -lpthread
+
+# Set DEBUG_WRITE to write debug images to storage
+ifneq ($(DEBUG_WRITE),)
+CXXFLAGS += -DDEBUG_WRITE
+LDLIBS += -lopencv_imgcodecs
+endif
 
 .PHONY: all %.eap dockerbuild clean
 


### PR DESCRIPTION
### Describe your changes

With this patch, one can easily enable writing debug images when running the make command (or by setting environment variables). Previously, the developer would need to uncomment lots of lines.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
