### PR TITLE
opcuagaugereader.cpp: Fix missed strncmp lengths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.1.0"
+            "version": "1.1.1"
         },
 	"configuration": {
 		"settingPage": "settings.html",

--- a/src/opcuagaugereader.cpp
+++ b/src/opcuagaugereader.cpp
@@ -96,11 +96,11 @@ static void update_local_param(const gchar &name, const uint32_t val)
     {
         clockwise = (1 == val);
     }
-    else if (0 == strncmp("centerX", &name, 4))
+    else if (0 == strncmp("centerX", &name, 7))
     {
         center_point.x = val;
     }
-    else if (0 == strncmp("centerY", &name, 4))
+    else if (0 == strncmp("centerY", &name, 7))
     {
         center_point.y = val;
     }


### PR DESCRIPTION
### Describe your changes

When midX and midY were changed to centerX and centerY, the strncmp limiters were not updated accordingly. This patch mitigates that.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
