### PR TITLE
Restrict port range

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.1.3"
+            "version": "1.1.4"
         },
 	"configuration": {
 		"settingPage": "settings.html",

--- a/manifest.json
+++ b/manifest.json
@@ -6,10 +6,6 @@
             "appName": "opcuagaugereader",
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "3.0",
-            "user": {
-                "group": "sdk",
-                "username": "sdk"
-            },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
             "version": "1.1.3"
@@ -18,13 +14,13 @@
 		"settingPage": "settings.html",
 		"paramConfig": [
 			{"name": "clockwise", "type": "bool:0,1", "default": "1"},
-			{"name": "maxX", "type": "int:min=0;max=1023", "default": "150"},
-			{"name": "maxY", "type": "int:min=0;max=575", "default": "150"},
-			{"name": "centerX", "type": "int:min=0;max=1023", "default": "100"},
-			{"name": "centerY", "type": "int:min=0;max=575", "default": "170"},
-			{"name": "minX", "type": "int:min=0;max=1023", "default": "50"},
-			{"name": "minY", "type": "int:min=0;max=575", "default": "150"},
-			{"name": "port", "type": "int:min=1", "default": "4840"}
+			{"name": "maxX", "type": "int:min=0,max=1023", "default": "150"},
+			{"name": "maxY", "type": "int:min=0,max=575", "default": "150"},
+			{"name": "centerX", "type": "int:min=0,max=1023", "default": "100"},
+			{"name": "centerY", "type": "int:min=0,max=575", "default": "170"},
+			{"name": "minX", "type": "int:min=0,max=1023", "default": "50"},
+			{"name": "minY", "type": "int:min=0,max=575", "default": "150"},
+			{"name": "port", "type": "int:min=1,max=65535", "default": "4840"}
 		]
 	}
     }

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,10 @@
             "appName": "opcuagaugereader",
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "3.0",
+            "user": {
+                "group": "sdk",
+                "username": "sdk"
+            },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
             "version": "1.1.3"

--- a/src/opcuaserver.cpp
+++ b/src/opcuaserver.cpp
@@ -35,6 +35,7 @@ bool OpcUaServer::LaunchServer(const unsigned int serverport)
     assert(nullptr == server);
     assert(nullptr == serverthread);
     assert(!running);
+    assert(1024 <= serverport && 65535 >= serverport);
 
     // Create an OPC UA server
     LOG_I("%s/%s: Create UA server serving on port %u", __FILE__, __FUNCTION__, serverport);


### PR DESCRIPTION
### Describe your changes

Let the ACAP framework choose the user to run as, and restrict the port range to allow setting non-privileged ports only (or there would be permission issues).
### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
