### PR TITLE
Handle race condition if OPC UA server is not up yet

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.1.4"
+            "version": "1.1.5"
         },
 	"configuration": {
 		"settingPage": "settings.html",

--- a/src/opcuaserver.cpp
+++ b/src/opcuaserver.cpp
@@ -93,7 +93,10 @@ void OpcUaServer::UpdateGaugeValue(double value)
     // Always update value even if there is no change; that will bump the
     // timestamp on the server so the client can see if the value is fresh or
     // ancient.
-    assert(nullptr != server);
+    if (nullptr == server)
+    {
+        return;
+    }
     UA_Variant newvalue;
     UA_Variant_setScalar(&newvalue, &value, &UA_TYPES[UA_TYPES_DOUBLE]);
     UA_NodeId currentNodeId = UA_NODEID_STRING(1, LABEL);


### PR DESCRIPTION
### Describe your changes

In the case where the image analysis has produced a value but the OPC UA server is not yet up and running, we were triggering an assert when updating the data. This is now change to no action.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
