### PR TITLE
Set capture resolution to 640x360 for maximum compatibility

### DIFF
--- a/html/js/opcuagaugereader.js
+++ b/html/js/opcuagaugereader.js
@@ -1,5 +1,5 @@
 const w = 640;
-const h = 480;
+const h = 360;
 const msize = 5;
 const State = {
 	Begin: Symbol(0),

--- a/manifest.json
+++ b/manifest.json
@@ -12,18 +12,18 @@
             },
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "1.1.7"
+            "version": "1.2.0"
         },
 	"configuration": {
 		"settingPage": "settings.html",
 		"paramConfig": [
 			{"name": "clockwise", "type": "bool:0,1", "default": "1"},
 			{"name": "maxX", "type": "int:min=0,max=639", "default": "150"},
-			{"name": "maxY", "type": "int:min=0,max=479", "default": "150"},
+			{"name": "maxY", "type": "int:min=0,max=359", "default": "150"},
 			{"name": "centerX", "type": "int:min=0,max=639", "default": "100"},
-			{"name": "centerY", "type": "int:min=0,max=479", "default": "170"},
+			{"name": "centerY", "type": "int:min=0,max=359", "default": "170"},
 			{"name": "minX", "type": "int:min=0,max=639", "default": "50"},
-			{"name": "minY", "type": "int:min=0,max=479", "default": "150"},
+			{"name": "minY", "type": "int:min=0,max=359", "default": "150"},
 			{"name": "port", "type": "int:min=1,max=65535", "default": "4840"}
 		]
 	}

--- a/src/opcuagaugereader.cpp
+++ b/src/opcuagaugereader.cpp
@@ -240,7 +240,7 @@ static gboolean initimageanalysis(void)
 {
     // The desired width and height of the BGR frame
     const unsigned int width = 640;
-    const unsigned int height = 480;
+    const unsigned int height = 360;
 
     // chooseStreamResolution gets the least resource intensive stream
     // that exceeds or equals the desired resolution specified above


### PR DESCRIPTION
### Describe your changes

Some devices were not happy with 640x480, which has been solved with 640x360. This would make the application compatible with as many models as possible. (And those who need to run higher resolutions and have models capable of it can simply alter the code before building the application.)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
