### PR TITLE
Add Podman for building with the ACAP SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,15 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
     strategy:
       matrix:
+        # Build both with Docker and Podman
+        builder: ["docker", "podman"]
         # Build both normal version and debug version
         debug_write: ["", "debug"]
     steps:
       - uses: actions/checkout@v4
       # Test all Makefile targets and make sure the ACAP files are created
       - name: Build
-        run: DEBUG_WRITE=${{ matrix.debug_write }} make -j dockerbuild
+        run: DEBUG_WRITE=${{ matrix.debug_write }} make -j ${{ matrix.builder }}build
       - name: Verify
         run: |
           for f in *.eap; do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH=aarch64
 ARG SDK_VERSION=12.2.0
-ARG SDK_IMAGE=axisecp/acap-native-sdk
+ARG SDK_IMAGE=docker.io/axisecp/acap-native-sdk
 ARG DEBUG_WRITE
 ARG BUILD_DIR=/opt/build
 ARG ACAP_BUILD_DIR="$BUILD_DIR"/app

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TARGET = opcuagaugereader
 OBJECTS = $(wildcard $(CURDIR)/src/*.cpp)
 RM ?= rm -f
+ARCHS = aarch64 armv7hf
 
 SDK_PKGS = gio-2.0 gio-unix-2.0 vdostream libcurl axparameter
 OWN_PKGS = opencv4 open62541
@@ -21,7 +22,7 @@ CXXFLAGS += -DDEBUG_WRITE
 DOCKER_ARGS += --build-arg DEBUG_WRITE=$(DEBUG_WRITE)
 endif
 
-.PHONY: all %.eap dockerbuild clean
+.PHONY: all %.docker %.podman dockerbuild podmanbuild clean
 
 all: $(TARGET)
 
@@ -29,11 +30,12 @@ $(TARGET): $(OBJECTS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LDLIBS) $^ -o $@ && \
 	$(STRIP) --strip-unneeded $@
 
-# docker build container targets
-%.eap:
-	DOCKER_BUILDKIT=1 docker build $(DOCKER_ARGS) --build-arg ARCH=$(*F) -o type=local,dest=. "$(CURDIR)"
+# Container build targets
+%.docker %.podman:
+	DOCKER_BUILDKIT=1 $(patsubst .%,%,$(suffix $@)) build --build-arg ARCH=$(*F) -o type=local,dest=. "$(CURDIR)"
 
-dockerbuild: armv7hf.eap aarch64.eap
+dockerbuild: $(addsuffix .docker,$(ARCHS))
+podmanbuild: $(addsuffix .podman,$(ARCHS))
 
 clean:
 	$(RM) $(TARGET) *.eap* *_LICENSE.txt pa*.conf

--- a/README.md
+++ b/README.md
@@ -51,13 +51,19 @@ For example:
 
 The build process uses the
 [ACAP SDK build container](https://hub.docker.com/r/axisecp/acap-sdk)
-and Docker.
+and Docker or Podman.
 
-The Docker commands are integrated in the [Makefile](Makefile), so if you have
-Docker and `make` on your computer all you need to do is:
+The Docker and Podman commands are integrated in the [Makefile](Makefile), so
+if you have Docker or Podman and `make` on your computer all you need to do is:
 
 ```sh
 make dockerbuild
+```
+
+or
+
+```sh
+make podmanbuild
 ```
 
 or perhaps build in parallel:
@@ -66,13 +72,28 @@ or perhaps build in parallel:
 make -j dockerbuild
 ```
 
+alternatively
+
+```sh
+make -j podmanbuild
+```
+
 If you do have Docker but no `make` on your system:
 
 ```sh
 # 32-bit ARM, e.g. ARTPEC-6- and ARTPEC-7-based devices
 DOCKER_BUILDKIT=1 docker build --build-arg ARCH=armv7hf -o type=local,dest=. .
-# 64-bit ARM, e.g. ARTPEC-8-based devices
+# 64-bit ARM, e.g. ARTPEC-8 and ARTPEC-9-based devices
 DOCKER_BUILDKIT=1 docker build --build-arg ARCH=aarch64 -o type=local,dest=. .
+```
+
+If you do have Podman but no `make` on your system:
+
+```sh
+# 32-bit ARM, e.g. ARTPEC-6- and ARTPEC-7-based devices
+podman build --build-arg ARCH=armv7hf -o type=local,dest=. .
+# 64-bit ARM, e.g. ARTPEC-8 and ARTPEC-9-based devices
+podman build --build-arg ARCH=aarch64 -o type=local,dest=. .
 ```
 
 ## Debug
@@ -90,9 +111,12 @@ or
 ```sh
 # 32-bit ARM, e.g. ARTPEC-6- and ARTPEC-7-based devices
 DOCKER_BUILDKIT=1 docker build --build-arg DEBUG_WRITE=y --build-arg ARCH=armv7hf -o type=local,dest=. .
-# 64-bit ARM, e.g. ARTPEC-8-based devices
+# 64-bit ARM, e.g. ARTPEC-8 and ARTPEC-9-based devices
 DOCKER_BUILDKIT=1 docker build --build-arg DEBUG_WRITE=y --build-arg ARCH=aarch64 -o type=local,dest=. .
 ```
+
+> [!TIP]
+> For Podman, use the same commands using `podman` instead of `docker`.
 
 ## Setup
 

--- a/include/DynamicStringHandler.hpp
+++ b/include/DynamicStringHandler.hpp
@@ -31,7 +31,9 @@ class DynamicStringHandler
 {
   public:
     DynamicStringHandler(const guint8 nbr);
-    DynamicStringHandler() : DynamicStringHandler(1){};
+    DynamicStringHandler() : DynamicStringHandler(1)
+    {
+    }
     ~DynamicStringHandler();
     void SetStrNumber(const guint8 newnbr);
     void UpdateStr(const double value);


### PR DESCRIPTION
### Describe your changes

This commit adds support for building with Podman; it was certainly possible before, but now included in the documentation and wrapped in the Makefile, it is much more convenient.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
