### PR TITLE
Push gauge reading as data event as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=aarch64
-ARG SDK_VERSION=12.7.0
+ARG SDK_VERSION=12.9.0
 ARG SDK_IMAGE=docker.io/axisecp/acap-native-sdk
 ARG DEBUG_WRITE
 ARG BUILD_DIR=/opt/build

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJECTS = $(wildcard $(CURDIR)/src/*.cpp)
 RM ?= rm -f
 ARCHS = aarch64 armv7hf
 
-SDK_PKGS = axparameter gio-2.0 gio-unix-2.0 libcurl vdostream
+SDK_PKGS = axevent axparameter gio-2.0 gio-unix-2.0 libcurl vdostream
 OWN_PKGS = opencv4 open62541
 
 CXXFLAGS += -Os -pipe -std=c++20 -Wall -Werror -Wextra

--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ Attach an OPC UA client to the port set in ACAP. The client will then be able
 to read the value (and its timestamp) from the application's OPC UA server.
 
 > [!NOTE]
-> The application will also log the gauge value in the camera's syslog.
+> The application will also log the gauge value in the camera's syslog and trigger a
+> data event in the camera's event system with the current gauge reading whenever the
+> value changes.
 
 ### Bonus
 

--- a/include/DynamicStringHandler.hpp
+++ b/include/DynamicStringHandler.hpp
@@ -36,10 +36,10 @@ class DynamicStringHandler
     }
     ~DynamicStringHandler();
     void SetStrNumber(const guint8 newnbr);
-    void UpdateStr(const double value, const gint8 precision = -1);
+    void UpdateStr(const std::string &value_str);
 
   private:
-    std::string RetrieveVapixCredentials(const char &username) const;
+    std::string RetrieveVapixCredentials(const gchar &username) const;
     gboolean VapixGet(const std::string &url);
 
     CURL *curl_;

--- a/include/EventPusher.hpp
+++ b/include/EventPusher.hpp
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2025, Axis Communications AB, Lund, Sweden
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <axevent.h>
+
+class EventPusher
+{
+  public:
+    EventPusher();
+    ~EventPusher();
+    gboolean Send(const gdouble value, const gboolean verbose_logs = FALSE) const;
+
+  private:
+    AXEventHandler *event_handler_;
+    gboolean initialized_;
+    guint event_id_;
+};

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "schemaVersion": "1.7.4",
+    "schemaVersion": "1.8.0",
     "acapPackageConf": {
         "setup": {
             "friendlyName": "OPC UA Gauge Reader",
@@ -8,7 +8,7 @@
             "embeddedSdkVersion": "3.0",
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "2.2.1"
+            "version": "2.3.0"
         },
         "configuration": {
             "settingPage": "settings.html",

--- a/src/DynamicStringHandler.cpp
+++ b/src/DynamicStringHandler.cpp
@@ -16,7 +16,6 @@
 
 #include <assert.h>
 #include <cstdlib>
-#include <format>
 #include <gio/gio.h>
 
 #include "DynamicStringHandler.hpp"
@@ -72,7 +71,7 @@ void DynamicStringHandler::SetStrNumber(const guint8 newnbr)
     LOG_I("Now using dynamic string number %u", newnbr);
 }
 
-void DynamicStringHandler::UpdateStr(const double value, const gint8 precision)
+void DynamicStringHandler::UpdateStr(const std::string &value_str)
 {
     // We don't need to update too frequently
     const auto nowtime = steady_clock::now();
@@ -81,7 +80,6 @@ void DynamicStringHandler::UpdateStr(const double value, const gint8 precision)
         return;
     }
 
-    const auto value_str = -1 < precision ? std::format("{:.{}f}", value, precision) : to_string(value);
     const auto url = "http://127.0.0.12/axis-cgi/dynamicoverlay.cgi?action=settext&text_index=" + to_string(nbr_) +
                      "&text=" + value_str;
     if (!VapixGet(url))
@@ -91,7 +89,7 @@ void DynamicStringHandler::UpdateStr(const double value, const gint8 precision)
     lastupdate_ = nowtime;
 }
 
-string DynamicStringHandler::RetrieveVapixCredentials(const char &username) const
+string DynamicStringHandler::RetrieveVapixCredentials(const gchar &username) const
 {
     GError *error = nullptr;
     auto connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);

--- a/src/EventPusher.cpp
+++ b/src/EventPusher.cpp
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2025, Axis Communications AB, Lund, Sweden
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <future>
+#include <stdexcept>
+
+#include "EventPusher.hpp"
+#include "common.hpp"
+
+using namespace std;
+
+static void declaration_complete(guint declaration, gpointer user_data)
+{
+    assert(NULL != user_data);
+    (void)declaration;
+
+    auto init = static_cast<gboolean *>(user_data);
+    *init = TRUE;
+    LOG_I("Event declaration complete!");
+}
+
+EventPusher::EventPusher() : event_handler_(ax_event_handler_new()), initialized_(FALSE)
+{
+    assert(nullptr != event_handler_);
+    GError *error = nullptr;
+
+    // Create keys, namespaces, and nice names for the event
+    auto set = ax_event_key_value_set_new();
+    const gdouble no_reading = -1.0;
+    ax_event_key_value_set_add_key_values(
+        set,
+        &error,
+        "topic0",
+        "tnsaxis",
+        "CameraApplicationPlatform",
+        AX_VALUE_TYPE_STRING,
+        "topic1",
+        "tnsaxis",
+        "GaugeReader",
+        AX_VALUE_TYPE_STRING,
+        "topic2",
+        "tnsaxis",
+        "Value",
+        AX_VALUE_TYPE_STRING,
+        "Value",
+        NULL,
+        &no_reading,
+        AX_VALUE_TYPE_DOUBLE,
+        NULL);
+
+    if (nullptr != error)
+    {
+        LOG_E("%s/%s: Could not add key values: %s", __FILE__, __FUNCTION__, error->message);
+        throw runtime_error(error->message);
+        g_error_free(error);
+    }
+
+    // Set nice names
+    ax_event_key_value_set_add_nice_names(set, "topic0", "tnsaxis", NULL, "Application", NULL);
+    ax_event_key_value_set_add_nice_names(set, "topic1", "tnsaxis", NULL, "OPC UA Gauge Reader", NULL);
+    ax_event_key_value_set_add_nice_names(set, "topic2", "tnsaxis", NULL, "Gauge Reader", NULL);
+    ax_event_key_value_set_add_nice_names(set, "Value", NULL, NULL, "Gauge value (percent)", NULL);
+
+    // Mark data value
+    ax_event_key_value_set_mark_as_data(set, "Value", NULL, NULL);
+    ax_event_key_value_set_mark_as_user_defined(set, "Value", NULL, "wstype:xs:float", NULL);
+
+    // Declare event
+    if (!ax_event_handler_declare(
+            event_handler_,
+            set,
+            TRUE, // Data event: only sent on explicit trigger, no automatic initial state
+            &event_id_,
+            declaration_complete,
+            &initialized_,
+            &error))
+    {
+        LOG_E("%s/%s: Could not declare: %s", __FILE__, __FUNCTION__, error->message);
+        throw runtime_error(error->message);
+        g_error_free(error);
+    }
+
+    // The key/value set is no longer needed
+    ax_event_key_value_set_free(set);
+}
+
+EventPusher::~EventPusher()
+{
+    assert(nullptr != event_handler_);
+    assert(0 != event_id_);
+
+    LOG_I("%s/%s: Undeclare event ...", __FILE__, __FUNCTION__);
+    ax_event_handler_undeclare(event_handler_, event_id_, nullptr);
+
+    LOG_I("%s/%s: Free eventhandler ...", __FILE__, __FUNCTION__);
+    ax_event_handler_free(event_handler_);
+}
+
+gboolean EventPusher::Send(const gdouble value, const gboolean verbose_logs) const
+{
+    if (!initialized_)
+    {
+        LOG_E("%s/%s: Event handling not yet initialized", __FILE__, __FUNCTION__);
+        return FALSE;
+    }
+
+    auto set = ax_event_key_value_set_new();
+
+    // Add the variable elements of the event to the set
+    ax_event_key_value_set_add_key_value(set, "Value", NULL, &value, AX_VALUE_TYPE_DOUBLE, NULL);
+
+    // Create the event
+    auto event = ax_event_new2(set, NULL);
+
+    // The key/value set is no longer needed
+    ax_event_key_value_set_free(set);
+
+    // Send the event
+    assert(nullptr != event_handler_);
+    GError *error = nullptr;
+    ax_event_handler_send_event(event_handler_, event_id_, event, &error);
+    if (nullptr != error)
+    {
+        LOG_E("Failed to send event: %s", error->message);
+        g_error_free(error);
+    }
+    else if (verbose_logs)
+    {
+        LOG_I("Data event sent with gauge value %f%%", value);
+    }
+
+    ax_event_free(event);
+
+    return TRUE;
+}

--- a/src/opcuagaugereader.cpp
+++ b/src/opcuagaugereader.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "DynamicStringHandler.hpp"
+#include "EventPusher.hpp"
 #include "Gauge.hpp"
 #include "ImageProvider.hpp"
 #include "OpcUaServer.hpp"
@@ -32,60 +33,62 @@
 using namespace cv;
 using namespace std;
 
-static GMainLoop *loop = nullptr;
+static GMainLoop *loop_ = nullptr;
 
-static mutex mtx;
+static mutex mtx_;
 
-static Gauge *gauge = nullptr;
-static OpcUaServer opcuaserver;
+static Gauge *gauge_ = nullptr;
+static OpcUaServer opcuaserver_;
+static EventPusher evpusher_;
+static gdouble lastvalue_ = -1.0;
 
-static ImageProvider *provider = nullptr;
-static Mat nv12_mat;
-static Mat gray_mat;
+static ImageProvider *provider_ = nullptr;
+static Mat nv12_mat_;
+static Mat gray_mat_;
 
-static DynamicStringHandler *dynstr_handler = nullptr;
-static ParamHandler *param_handler = nullptr;
+static DynamicStringHandler *dynstr_handler_ = nullptr;
+static ParamHandler *param_handler_ = nullptr;
 
 static void restart_opcuaserver(const guint32 port)
 {
-    mtx.lock();
-    if (opcuaserver.IsRunning())
+    mtx_.lock();
+    if (opcuaserver_.IsRunning())
     {
-        opcuaserver.ShutDownServer();
+        opcuaserver_.ShutDownServer();
     }
-    if (!opcuaserver.LaunchServer(port))
+    if (!opcuaserver_.LaunchServer(port))
     {
         LOG_E("%s/%s: Failed to launch OPC UA server", __FILE__, __FUNCTION__);
         assert(false);
     }
-    mtx.unlock();
+    mtx_.unlock();
 }
 
 static void replace_gauge()
 {
-    mtx.lock();
-    if (nullptr != gauge)
+    mtx_.lock();
+    if (nullptr != gauge_)
     {
-        delete gauge;
-        gauge = nullptr;
+        delete gauge_;
+        gauge_ = nullptr;
     }
-    mtx.unlock();
+    mtx_.unlock();
 }
 
 static void set_dynstr_nbr(const guint8 port)
 {
-    assert(nullptr != dynstr_handler);
-    mtx.lock();
-    dynstr_handler->SetStrNumber(port);
-    mtx.unlock();
+    assert(nullptr != dynstr_handler_);
+    mtx_.lock();
+    dynstr_handler_->SetStrNumber(port);
+    mtx_.unlock();
 }
 
 static gboolean imageanalysis(gpointer data)
 {
     (void)data;
     // Get the latest NV12 image frame from VDO using the imageprovider
-    assert(nullptr != provider);
-    auto buf = provider->GetLastFrameBlocking();
+    assert(nullptr != provider_);
+    auto buf = provider_->GetLastFrameBlocking();
     if (nullptr == buf)
     {
         LOG_I("%s/%s: No more frames available, exiting", __FILE__, __FUNCTION__);
@@ -95,27 +98,27 @@ static gboolean imageanalysis(gpointer data)
     // Assign the VDO image buffer to the nv12_mat OpenCV Mat.
     // This specific Mat is used as it is the one we created for NV12,
     // which has a different layout than e.g., BGR.
-    mtx.lock();
-    nv12_mat.data = static_cast<uint8_t *>(vdo_buffer_get_data(buf));
+    mtx_.lock();
+    nv12_mat_.data = static_cast<uint8_t *>(vdo_buffer_get_data(buf));
 
     // Convert the NV12 data to GRAY
-    cvtColor(nv12_mat, gray_mat, COLOR_YUV2GRAY_NV12, 1);
+    cvtColor(nv12_mat_, gray_mat_, COLOR_YUV2GRAY_NV12, 1);
 
     // Create gauge if nonexistent
-    if (nullptr == gauge)
+    if (nullptr == gauge_)
     {
         LOG_I("%s/%s: Set up new Gauge", __FILE__, __FUNCTION__);
-        assert(nullptr != param_handler);
-        gauge = new Gauge(
-            gray_mat,
-            param_handler->GetCenterPoint(),
-            param_handler->GetMinPoint(),
-            param_handler->GetMaxPoint(),
-            param_handler->GetClockwise());
+        assert(nullptr != param_handler_);
+        gauge_ = new Gauge(
+            gray_mat_,
+            param_handler_->GetCenterPoint(),
+            param_handler_->GetMinPoint(),
+            param_handler_->GetMaxPoint(),
+            param_handler_->GetClockwise());
     }
-    assert(nullptr != gauge);
-    auto value = gauge->ComputeGaugeValue(gray_mat);
-    mtx.unlock();
+    assert(nullptr != gauge_);
+    auto value = gauge_->ComputeGaugeValue(gray_mat_);
+    mtx_.unlock();
     // Successfully read values range between 0 and 100 percent; if no value
     // could be read the computation will return -1
     assert(value <= 100.0);
@@ -125,32 +128,35 @@ static gboolean imageanalysis(gpointer data)
     }
     else
     {
-        const auto rounddecimals = param_handler->GetRoundToDecimals();
+        const auto rounddecimals = param_handler_->GetRoundToDecimals();
+        string value_str;
         if (-1 < rounddecimals)
         {
             // Round value if limited amount of decimals is requested
             const double factor = pow(10.0, rounddecimals);
             value = round(value * factor) / factor;
-            LOG_I(
-                "%s/%s: Value (with %i decimals) was %s",
-                __FILE__,
-                __FUNCTION__,
-                rounddecimals,
-                std::format("{:.{}f}", value, rounddecimals).c_str());
+            value_str = std::format("{:.{}f}", value, rounddecimals);
+            LOG_I("%s/%s: Value (with %i decimals) was %s", __FILE__, __FUNCTION__, rounddecimals, value_str.c_str());
         }
         else
         {
-            LOG_I("%s/%s: Value (with unlimited decimals) was %f", __FILE__, __FUNCTION__, value);
+            value_str = std::to_string(value);
+            LOG_I("%s/%s: Value (with unlimited decimals) was %s", __FILE__, __FUNCTION__, value_str.c_str());
         }
-        opcuaserver.UpdateGaugeValue(value);
-        if (nullptr != dynstr_handler)
+        opcuaserver_.UpdateGaugeValue(value);
+        if (value != lastvalue_)
         {
-            dynstr_handler->UpdateStr(value, rounddecimals);
+            assert(nullptr != dynstr_handler_);
+            dynstr_handler_->UpdateStr(value_str);
+            if (evpusher_.Send(value, TRUE))
+            {
+                lastvalue_ = value;
+            }
         }
     }
 
     // Release the VDO frame buffer
-    provider->ReturnFrame(*buf);
+    provider_->ReturnFrame(*buf);
 
     return TRUE;
 }
@@ -173,23 +179,23 @@ static gboolean initimageanalysis(void)
 
     LOG_I("Creating VDO image provider and creating stream %d x %d", streamWidth, streamHeight);
     // TODO: Could we use the subformat Y800 to get gray 1-channel image directly?
-    provider = new ImageProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
-    if (!provider)
+    provider_ = new ImageProvider(streamWidth, streamHeight, 2, VDO_FORMAT_YUV);
+    if (!provider_)
     {
         LOG_E("%s/%s: Failed to create ImageProvider", __FILE__, __FUNCTION__);
         return FALSE;
     }
 
     LOG_I("Start fetching video frames from VDO");
-    if (!ImageProvider::StartFrameFetch(*provider))
+    if (!ImageProvider::StartFrameFetch(*provider_))
     {
         LOG_E("%s/%s: Failed to fetch frames from VDO", __FILE__, __FUNCTION__);
         return FALSE;
     }
 
     // OpenCV represents NV12 with 1.5 bytes per pixel
-    nv12_mat = Mat(height * 3 / 2, width, CV_8UC1);
-    gray_mat = Mat(height, width, CV_8UC1);
+    nv12_mat_ = Mat(height * 3 / 2, width, CV_8UC1);
+    gray_mat_ = Mat(height, width, CV_8UC1);
 
     return TRUE;
 }
@@ -201,11 +207,11 @@ static void signalHandler(int signal_num)
     case SIGTERM:
     case SIGABRT:
     case SIGINT:
-        if (nullptr != provider)
+        if (nullptr != provider_)
         {
-            ImageProvider::StopFrameFetch(*provider);
+            ImageProvider::StopFrameFetch(*provider_);
         }
-        g_main_loop_quit(loop);
+        g_main_loop_quit(loop_);
         break;
     default:
         break;
@@ -249,12 +255,12 @@ int main(int argc, char *argv[])
     }
 
     // Init dynamic string handling
-    dynstr_handler = new DynamicStringHandler();
+    dynstr_handler_ = new DynamicStringHandler();
 
     // Init parameter handling (will also launch OPC UA server)
     LOG_I("Init parameter handling and launch OPC UA server ...");
-    param_handler = new ParamHandler(app_name, restart_opcuaserver, replace_gauge, set_dynstr_nbr);
-    if (nullptr == param_handler)
+    param_handler_ = new ParamHandler(app_name, restart_opcuaserver, replace_gauge, set_dynstr_nbr);
+    if (nullptr == param_handler_)
     {
         LOG_E("%s/%s: Failed to set up parameter handler and launch OPC UA server", __FILE__, __FUNCTION__);
         result = EXIT_FAILURE;
@@ -278,24 +284,24 @@ int main(int argc, char *argv[])
     }
 
     LOG_I("Start main loop ...");
-    assert(nullptr == loop);
-    loop = g_main_loop_new(nullptr, FALSE);
-    g_main_loop_run(loop);
+    assert(nullptr == loop_);
+    loop_ = g_main_loop_new(nullptr, FALSE);
+    g_main_loop_run(loop_);
 
     // Cleanup
     LOG_I("Shutdown ...");
-    g_main_loop_unref(loop);
-    if (nullptr != provider)
+    g_main_loop_unref(loop_);
+    if (nullptr != provider_)
     {
-        delete provider;
+        delete provider_;
     }
-    opcuaserver.ShutDownServer();
+    opcuaserver_.ShutDownServer();
 
 exit_param:
-    delete param_handler;
+    delete param_handler_;
 
 exit:
-    delete dynstr_handler;
+    delete dynstr_handler_;
     LOG_I("Exiting!");
     closelog();
 


### PR DESCRIPTION
### Describe your changes

The reading is now pushed as a data event in the Axis event stream as well, meaning it can directly be consumed by any existing VMS with capability to consume standard Axis event data.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
