### PR TITLE
Set minimum AXIS OS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=aarch64
-ARG SDK_VERSION=12.10.0
+ARG SDK_VERSION=12.11.0
 ARG SDK_IMAGE=docker.io/axisecp/acap-native-sdk
 ARG DEBUG_WRITE
 ARG BUILD_DIR=/opt/build

--- a/manifest.json
+++ b/manifest.json
@@ -4,13 +4,14 @@
         "setup": {
             "friendlyName": "OPC UA Gauge Reader",
             "appName": "opcuagaugereader",
-            "vendor": "Axis Communications AB",
+            "vendor": "Axis Communications",
+            "vendorId": "1234567890",
             "vendorUrl": "https://www.axis.com/",
             "runMode": "respawn",
-            "version": "2.4.0",
-            "vendorId": "1234567890",
+            "version": "2.4.1",
             "compatibleOsVersions": [
                 {
+                    "min": "12.11",
                     "max": "13"
                 }
             ]


### PR DESCRIPTION
## Describe your changes

Unless compatibleOsVersions.min is set in [manifest.json](manifest.json), the ACAP SDK will use its default value which is a specifc version (such as 12.11.79) for that ACAP SDK. Here we broaden the scope to allow installation for all 12.11.x AXIS OS versions (and newer).

## Checklist before asking for a review

<!--
Mark the boxes that apply with an 'x'. You can also fill these out after creating the PR. If you're unsure about any, just ask. We're here to help! This is just a reminder of what we're looking for before merging your changes.
-->

- [x] I've reviewed my own changes
- [x] I've made sure my changes align with the existing style in the repository
